### PR TITLE
fix: keep deleted output and import value trough ssm

### DIFF
--- a/src/esb-generic-services-stack.ts
+++ b/src/esb-generic-services-stack.ts
@@ -1,4 +1,5 @@
 import * as core from 'aws-cdk-lib';
+import { CfnOutput } from 'aws-cdk-lib';
 import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as kms from 'aws-cdk-lib/aws-kms';
@@ -8,8 +9,6 @@ import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 export class esbGenericServicesStack extends core.Stack {
-
-  public readonly eformSqsArn: string; //used in IAM policy,
 
   constructor(scope: Construct, id: string, props: core.StackProps) {
     super(scope, id, props);
@@ -64,7 +63,16 @@ export class esbGenericServicesStack extends core.Stack {
         maxReceiveCount: 1,
       },
     });
-    this.eformSqsArn = eformSqs.queueArn;
+
+    new ssm.StringParameter(this, 'esb-eform-submissions-queue-arn', {
+      parameterName: '/cdk/esb/queue/arn',
+      stringValue: eformSqs.queueArn,
+    });
+
+    new CfnOutput(this, 'esb-eform-submissions-queue-arn-output', { // TODO remove this, however deployment fail right now as this output is deleted by the cloudformation upgrade.
+      value: eformSqs.queueArn,
+      exportName: 'esbGenericServices:esbAcceptanceesbGenericServicesExportsOutputFnGetAttesbeformsubmissionsqueue89F903F0ArnFBA3247A',
+    });
 
     /**
      * Policy document: custom access policy for eform sqs.

--- a/src/esb-iam-stack.ts
+++ b/src/esb-iam-stack.ts
@@ -1,24 +1,24 @@
 import * as core from 'aws-cdk-lib';
+import { StackProps, aws_ssm as ssm } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { esbIAMMule } from './iam-structs/esb-mule-struct';
 import { statics } from './statics';
 
-export interface iamStackProps extends core.StackProps {
-  esbSqsArn: string;
-};
 
 export class esbIamStack extends core.Stack {
-  constructor(scope: Construct, id: string, props: iamStackProps) {
+  constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
     core.Tags.of(this).add('cdkManaged', 'yes');
     core.Tags.of(this).add('Project', 'esb');
+
+    const esbSqsArn = ssm.StringParameter.valueForStringParameter(this, '/cdk/esb/queue/arn');
 
     /**
      * IAM Construct for mule
      */
     new esbIAMMule(this, 'esbMule', {
       iamAccountPrincipal: statics.AWS_ACCOUNT_IAM,
-      esbSqsArn: props.esbSqsArn,
+      esbSqsArn: esbSqsArn,
     });
   }
 }

--- a/src/pipeline-stack.ts
+++ b/src/pipeline-stack.ts
@@ -20,15 +20,13 @@ class esbStage extends Stage {
     /**
      * Stack: esb generic services
      */
-    const esbGenericsStack = new esbGenericServicesStack(this, 'esbGenericServices', {});
+    new esbGenericServicesStack(this, 'esbGenericServices', {});
 
     /**
      * Stack: esb iam
      * Depends on GenericServicesStack
      */
-    new esbIamStack(this, 'esbIam', {
-      esbSqsArn: esbGenericsStack.eformSqsArn,
-    });
+    new esbIamStack(this, 'esbIam');
   }
 }
 

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -284,33 +284,6 @@ Object {
                   "Version": "1",
                 },
                 "Configuration": Object {
-                  "ActionMode": "CHANGE_SET_EXECUTE",
-                  "ChangeSetName": "PipelineChange",
-                  "StackName": "esbAcceptance-esbGenericServices",
-                },
-                "Name": "esbGenericServices.Deploy",
-                "RoleArn": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::315037222840:role/cdk-hnb659fds-deploy-role-315037222840-eu-west-1",
-                    ],
-                  ],
-                },
-                "RunOrder": 2,
-              },
-              Object {
-                "ActionTypeId": Object {
-                  "Category": "Deploy",
-                  "Owner": "AWS",
-                  "Provider": "CloudFormation",
-                  "Version": "1",
-                },
-                "Configuration": Object {
                   "ActionMode": "CHANGE_SET_REPLACE",
                   "Capabilities": "CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND",
                   "ChangeSetName": "PipelineChange",
@@ -348,7 +321,34 @@ Object {
                     ],
                   ],
                 },
-                "RunOrder": 3,
+                "RunOrder": 1,
+              },
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Deploy",
+                  "Owner": "AWS",
+                  "Provider": "CloudFormation",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "ActionMode": "CHANGE_SET_EXECUTE",
+                  "ChangeSetName": "PipelineChange",
+                  "StackName": "esbAcceptance-esbGenericServices",
+                },
+                "Name": "esbGenericServices.Deploy",
+                "RoleArn": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::315037222840:role/cdk-hnb659fds-deploy-role-315037222840-eu-west-1",
+                    ],
+                  ],
+                },
+                "RunOrder": 2,
               },
               Object {
                 "ActionTypeId": Object {
@@ -375,7 +375,7 @@ Object {
                     ],
                   ],
                 },
-                "RunOrder": 4,
+                "RunOrder": 2,
               },
             ],
             "Name": "esbAcceptance",
@@ -437,33 +437,6 @@ Object {
                   "Version": "1",
                 },
                 "Configuration": Object {
-                  "ActionMode": "CHANGE_SET_EXECUTE",
-                  "ChangeSetName": "PipelineChange",
-                  "StackName": "esbProduction-esbGenericServices",
-                },
-                "Name": "esbGenericServices.Deploy",
-                "RoleArn": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::196212984627:role/cdk-hnb659fds-deploy-role-196212984627-eu-west-1",
-                    ],
-                  ],
-                },
-                "RunOrder": 2,
-              },
-              Object {
-                "ActionTypeId": Object {
-                  "Category": "Deploy",
-                  "Owner": "AWS",
-                  "Provider": "CloudFormation",
-                  "Version": "1",
-                },
-                "Configuration": Object {
                   "ActionMode": "CHANGE_SET_REPLACE",
                   "Capabilities": "CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND",
                   "ChangeSetName": "PipelineChange",
@@ -501,7 +474,34 @@ Object {
                     ],
                   ],
                 },
-                "RunOrder": 3,
+                "RunOrder": 1,
+              },
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Deploy",
+                  "Owner": "AWS",
+                  "Provider": "CloudFormation",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "ActionMode": "CHANGE_SET_EXECUTE",
+                  "ChangeSetName": "PipelineChange",
+                  "StackName": "esbProduction-esbGenericServices",
+                },
+                "Name": "esbGenericServices.Deploy",
+                "RoleArn": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::196212984627:role/cdk-hnb659fds-deploy-role-196212984627-eu-west-1",
+                    ],
+                  ],
+                },
+                "RunOrder": 2,
               },
               Object {
                 "ActionTypeId": Object {
@@ -528,7 +528,7 @@ Object {
                     ],
                   ],
                 },
-                "RunOrder": 4,
+                "RunOrder": 2,
               },
             ],
             "Name": "esbProduction",


### PR DESCRIPTION
- Deployment failed due to deleted stack output, so added the output explicitly.
- Export the queue arn via ssm parameter
- Import quque arn via ssm parameter in iam stack.