### PR TITLE
fix: add delteted stack output for prod as well

### DIFF
--- a/src/esb-generic-services-stack.ts
+++ b/src/esb-generic-services-stack.ts
@@ -10,7 +10,7 @@ import { Construct } from 'constructs';
 
 export class esbGenericServicesStack extends core.Stack {
 
-  constructor(scope: Construct, id: string, props: core.StackProps) {
+  constructor(scope: Construct, id: string, props: core.StackProps, isAcceptance: boolean) {
     super(scope, id, props);
     core.Tags.of(this).add('cdkManaged', 'yes');
     core.Tags.of(this).add('Project', 'esb');
@@ -69,10 +69,17 @@ export class esbGenericServicesStack extends core.Stack {
       stringValue: eformSqs.queueArn,
     });
 
-    new CfnOutput(this, 'esb-eform-submissions-queue-arn-output', { // TODO remove this, however deployment fail right now as this output is deleted by the cloudformation upgrade.
-      value: eformSqs.queueArn,
-      exportName: 'esbAcceptance-esbGenericServices:esbAcceptanceesbGenericServicesExportsOutputFnGetAttesbeformsubmissionsqueue89F903F0ArnFBA3247A',
-    });
+    if (isAcceptance) { // TODO remove this, however deployment fail right now as this output is deleted by the cloudformation upgrade.
+      new CfnOutput(this, 'esb-eform-submissions-queue-arn-output', {
+        value: eformSqs.queueArn,
+        exportName: 'esbAcceptance-esbGenericServices:esbAcceptanceesbGenericServicesExportsOutputFnGetAttesbeformsubmissionsqueue89F903F0ArnFBA3247A',
+      });
+    } else {
+      new CfnOutput(this, 'esb-eform-submissions-queue-arn-output', {
+        value: eformSqs.queueArn,
+        exportName: 'esbProduction-esbGenericServices:esbProductionesbGenericServicesExportsOutputFnGetAttesbeformsubmissionsqueue89F903F0Arn9207A351',
+      });
+    }
 
     /**
      * Policy document: custom access policy for eform sqs.

--- a/src/pipeline-stack.ts
+++ b/src/pipeline-stack.ts
@@ -14,13 +14,13 @@ import { statics } from './statics';
 
 class esbStage extends Stage {
 
-  constructor(scope: Construct, id: string, props: StageProps) {
+  constructor(scope: Construct, id: string, props: StageProps, isAcceptance: boolean) {
     super(scope, id, props);
 
     /**
      * Stack: esb generic services
      */
-    const queues = new esbGenericServicesStack(this, 'esbGenericServices', {});
+    const queues = new esbGenericServicesStack(this, 'esbGenericServices', {}, isAcceptance);
 
     /**
      * Stack: esb iam
@@ -66,7 +66,7 @@ export class PipelineStack extends Stack {
         account: statics.AWS_ACCOUNT_AUTH_ACCP,
         region: 'eu-west-1',
       },
-    }),
+    }, true),
     );
 
     pipeline.addStage( new esbStage(this, 'esbProduction', {
@@ -74,7 +74,7 @@ export class PipelineStack extends Stack {
         account: statics.AWS_ACCCOUNT_AUTH_PROD,
         region: 'eu-west-1',
       },
-    }),
+    }, false),
     );
   }
 }


### PR DESCRIPTION
Cloudformation tries to delete a stack output that is used in an different stack.
By adding this output explicitly the deployment is succesful (tested on accp).
After deployment the output can be removed